### PR TITLE
Fix expanded annotationView frame position

### DIFF
--- a/JPSThumbnailAnnotation/JPSThumbnailAnnotationView.m
+++ b/JPSThumbnailAnnotation/JPSThumbnailAnnotationView.m
@@ -187,8 +187,7 @@ static CGFloat const kJPSThumbnailAnnotationViewAnimationDuration = 0.25f;
     self.state = JPSThumbnailAnnotationViewStateAnimating;
     
     [self animateBubbleWithDirection:JPSThumbnailAnnotationViewAnimationDirectionGrow];
-    self.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y, self.frame.size.width+kJPSThumbnailAnnotationViewExpandOffset, self.frame.size.height);
-    self.centerOffset = CGPointMake(kJPSThumbnailAnnotationViewExpandOffset/2.0f, -kJPSThumbnailAnnotationViewVerticalOffset);
+    self.bounds = CGRectMake(self.bounds.origin.x-kJPSThumbnailAnnotationViewExpandOffset/2, self.bounds.origin.y, self.bounds.size.width+kJPSThumbnailAnnotationViewExpandOffset, self.bounds.size.height);
     [UIView animateWithDuration:kJPSThumbnailAnnotationViewAnimationDuration/2.0f delay:kJPSThumbnailAnnotationViewAnimationDuration options:UIViewAnimationOptionCurveEaseInOut animations:^{
         [self setDetailGroupAlpha:1.0f];
     } completion:^(BOOL finished) {
@@ -201,10 +200,10 @@ static CGFloat const kJPSThumbnailAnnotationViewAnimationDuration = 0.25f;
     
     self.state = JPSThumbnailAnnotationViewStateAnimating;
 
-    self.frame = CGRectMake(self.frame.origin.x,
-                            self.frame.origin.y,
-                            self.frame.size.width - kJPSThumbnailAnnotationViewExpandOffset,
-                            self.frame.size.height);
+    self.bounds = CGRectMake(self.bounds.origin.x + kJPSThumbnailAnnotationViewExpandOffset/2,
+                             self.bounds.origin.y,
+                             self.bounds.size.width - kJPSThumbnailAnnotationViewExpandOffset,
+                             self.bounds.size.height);
     
     [UIView animateWithDuration:kJPSThumbnailAnnotationViewAnimationDuration/2.0f
                           delay:0.0f


### PR DESCRIPTION
Fix annotationView frame position. Frame property does not contain the
location in the screen, bounds could be used instead. With this fix it
is no longer necessary to use the offset command.

This is how view was:
<a href="url"><img src="https://cloud.githubusercontent.com/assets/7589923/21818911/e2c6177a-d769-11e6-846f-7964ea74d0be.png" align="center" height="552" width="310" ></a>

This is how the view is now after the fix:
<a href="url"><img src="https://cloud.githubusercontent.com/assets/7589923/21818930/f498fc88-d769-11e6-83ef-7fcc87a1aba1.png" align="center" height="552" width="310" ></a>


