### PR TITLE
Added ContentMode to JPSThumbnail

### DIFF
--- a/JPSThumbnailAnnotation/JPSThumbnail.h
+++ b/JPSThumbnailAnnotation/JPSThumbnail.h
@@ -18,5 +18,6 @@ typedef void (^ActionBlock)();
 @property (nonatomic, copy) NSString *subtitle;
 @property (nonatomic, assign) CLLocationCoordinate2D coordinate;
 @property (nonatomic, copy) ActionBlock disclosureBlock;
+@property (nonatomic) UIViewContentMode contentMode;
 
 @end

--- a/JPSThumbnailAnnotation/JPSThumbnail.m
+++ b/JPSThumbnailAnnotation/JPSThumbnail.m
@@ -10,4 +10,12 @@
 
 @implementation JPSThumbnail
 
+- (instancetype)init{
+    self = [super init];
+    if(self){
+        self.contentMode = UIViewContentModeScaleAspectFill;
+    }
+    return self;
+}
+
 @end

--- a/JPSThumbnailAnnotation/JPSThumbnailAnnotationView.m
+++ b/JPSThumbnailAnnotation/JPSThumbnailAnnotationView.m
@@ -128,6 +128,7 @@ static CGFloat const kJPSThumbnailAnnotationViewAnimationDuration = 0.25f;
     self.subtitleLabel.text = thumbnail.subtitle;
     self.imageView.image = thumbnail.image;
     self.disclosureBlock = thumbnail.disclosureBlock;
+    self.imageView.contentMode = thumbnail.contentMode;
 }
 
 #pragma mark - JPSThumbnailAnnotationViewProtocol


### PR DESCRIPTION
Added for each thumbnail the option to choose content mode, by default
is aspect fill (even if not defined), but it can be set to aspect fit
or others.

With this feature all images keep their aspect and allow users to
choose other options.